### PR TITLE
Allow count prefix and default resize value

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Just add the following into your .vimrc file:
 
 
 ```
-noremap <silent> <C-Up> :ObviousResizeUp<CR>
-noremap <silent> <C-Down> :ObviousResizeDown<CR>
-noremap <silent> <C-Left> :ObviousResizeLeft<CR>
-noremap <silent> <C-Right> :ObviousResizeRight<CR>
+noremap <silent> <C-Up> :<C-U>ObviousResizeUp<CR>
+noremap <silent> <C-Down> :<C-U>ObviousResizeDown<CR>
+noremap <silent> <C-Left> :<C-U>ObviousResizeLeft<CR>
+noremap <silent> <C-Right> :<C-U>ObviousResizeRight<CR>
 ```
 
 ## Specifying the Resize Amount
@@ -19,6 +19,8 @@ Windows get resized 1 line by default, which you can change in your .vimrc file:
 ```
 let g:obvious_resize_default = 2
 ```
+
+Like most Vim commands, you can prefix your command with an optional count: `5<C-Up>` will resize by 5 lines.
 
 You can also specify a count in your remap:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Obvious Resize
+# Obvious Resize
 
 A plugin for easy resizing of Vim windows.
 
@@ -12,8 +12,16 @@ noremap <silent> <C-Left> :ObviousResizeLeft<CR>
 noremap <silent> <C-Right> :ObviousResizeRight<CR>
 ```
 
-Optionally you can pass a count to :ObviousResize to resize the pane by that amount.
+## Specifying the Resize Amount
+
+Windows get resized 1 line by default, which you can change in your .vimrc file:
 
 ```
-noremap <silent> <C-Up> :ObviousResizeUp 5<CR>
+let g:obvious_resize_default = 2
+```
+
+You can also specify a count in your remap:
+
+```
+noremap <silent> <C-Up> :<C-U>ObviousResizeUp 5<CR>
 ```

--- a/autoload/obviousresize.vim
+++ b/autoload/obviousresize.vim
@@ -31,7 +31,13 @@ endfunction
 
 " Resize the current window at the provided direction
 function! obviousresize#Resize(dir, ...)
-  let counter = a:0 == 1 ? a:1 : g:obvious_resize_default
+  if v:count
+    let counter = v:count
+  elseif a:0 == 1
+    let counter = a:1
+  else
+    let counter = g:obvious_resize_default
+  endif
   let crr_win = winnr()
 
   if a:dir == 'h'

--- a/autoload/obviousresize.vim
+++ b/autoload/obviousresize.vim
@@ -4,8 +4,12 @@
 if &cp || exists("g:_loaded_obviousresize") 
  finish
 endif
-
 let g:_loaded_obviousresize = 1
+
+if !exists("g:obvious_resize_default")
+  let g:obvious_resize_default = 2
+endif
+
 let s:cpo_save = &cpo
 set cpo&vim
 
@@ -27,13 +31,9 @@ endfunction
 
 " Resize the current window at the provided direction
 function! obviousresize#Resize(dir, ...)
-  if  a:0 == 1
-    let counter = a:1
-  else
-    let counter = 1
-  endif
-
+  let counter = a:0 == 1 ? a:1 : g:obvious_resize_default
   let crr_win = winnr()
+
   if a:dir == 'h'
     " resize to the left
     if s:HasWindow('h') && !s:HasWindow('l')
@@ -85,4 +85,3 @@ endfunction
 
 let &cpo=s:cpo_save
 unlet s:cpo_save
-


### PR DESCRIPTION
- Allow user to specify `g:obvious_resize_default`
- Allow a count prefix like most other Vim commands