### PR TITLE
Default g:obvious_resize_default to 1

### DIFF
--- a/autoload/obviousresize.vim
+++ b/autoload/obviousresize.vim
@@ -7,7 +7,7 @@ endif
 let g:_loaded_obviousresize = 1
 
 if !exists("g:obvious_resize_default")
-  let g:obvious_resize_default = 2
+  let g:obvious_resize_default = 1
 endif
 
 let s:cpo_save = &cpo


### PR DESCRIPTION
The README states that the default is 1, but I set it to 2 in my commit.